### PR TITLE
PR for issue "Add total usage per day"

### DIFF
--- a/Frontend/all_statistics.html
+++ b/Frontend/all_statistics.html
@@ -92,8 +92,8 @@
 
                     container.innerHTML = data.data.map(day => `
                         <div class="stats-container">
-                            <h2 class="date-header">${day.date}</h2>
-                            <div class="stats-summary">
+                            <div class="date-header-container">
+                                <h2 class="date-header">${day.date}</h2>
                                 <span class="room-count">Unique Rooms: ${day.room_count}</span>
                             </div>
                             <div class="table-container">

--- a/Frontend/all_statistics.html
+++ b/Frontend/all_statistics.html
@@ -9,6 +9,9 @@
 <body>
     <a href="/Frontend/index.html" class="back-button">← Back to Control Panel</a>
     <h1>All Curtain Control Statistics</h1>
+    <div id="totalStatsContainer" class="total-stats-container">
+        <div class="loading">Loading total statistics...</div>
+    </div>
     <div id="statsContainer">
         <div class="loading">Loading statistics...</div>
     </div>
@@ -72,6 +75,15 @@
                 .then(response => response.json())
                 .then(data => {
                     const container = document.getElementById('statsContainer');
+                    const totalContainer = document.getElementById('totalStatsContainer');
+
+                    // Display total unique rooms count
+                    totalContainer.innerHTML = `
+                        <div class="total-unique-rooms">
+                            <span class="total-label">Total Unique Rooms (All Time):</span>
+                            <span class="total-count">${data.total_unique_rooms}</span>
+                        </div>
+                    `;
 
                     if (data.data.length === 0) {
                         container.innerHTML = '<div class="no-data">No statistics available</div>';
@@ -81,6 +93,9 @@
                     container.innerHTML = data.data.map(day => `
                         <div class="stats-container">
                             <h2 class="date-header">${day.date}</h2>
+                            <div class="stats-summary">
+                                <span class="room-count">Unique Rooms: ${day.room_count}</span>
+                            </div>
                             <div class="table-container">
                                 ${createTableHTML(day.stats)}
                             </div>
@@ -94,6 +109,7 @@
                             Error loading statistics. Please try again later.
                         </div>
                     `;
+                    document.getElementById('totalStatsContainer').innerHTML = '';
                 });
         }
 

--- a/Frontend/css/all_statistics_style.css
+++ b/Frontend/css/all_statistics_style.css
@@ -46,14 +46,33 @@ h1 {
     margin-bottom: 40px;
 }
 
-.date-header {
+.date-header-container {
     background-color: var(--button-color);
-    color: var(--text-color);
-    padding: 12px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0;
     border-radius: 8px 8px 0 0;
     margin-bottom: 0;
+}
+
+.date-header {
+    background-color: transparent;
+    color: var(--text-color);
+    padding: 12px 20px;
+    border-radius: 0;
+    margin: 0;
     font-size: 18px;
     font-weight: bold;
+}
+
+.room-count {
+    font-weight: 600;
+    display: inline-block;
+    padding: 4px 12px;
+    margin-right: 20px;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0.2);
 }
 
 .table-container {
@@ -154,14 +173,6 @@ tr:last-child td {
     font-size: 16px;
     display: flex;
     justify-content: flex-end;
-}
-
-.room-count {
-    font-weight: 600;
-    display: inline-block;
-    padding: 4px 8px;
-    border-radius: 4px;
-    background-color: rgba(255, 255, 255, 0.2);
 }
 
 .dark-mode .room-count {

--- a/Frontend/css/all_statistics_style.css
+++ b/Frontend/css/all_statistics_style.css
@@ -147,8 +147,57 @@ tr:last-child td {
     background-color: #1d4ed8;
 }
 
-/* Add totals row styling */
-.totals-row {
-    font-weight: bold;
-    background-color: #f8fafc;
+.stats-summary {
+    background-color: var(--button-color);
+    padding: 0 20px 12px;
+    color: var(--text-color);
+    font-size: 16px;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.room-count {
+    font-weight: 600;
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+.dark-mode .room-count {
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+.total-stats-container {
+    background-color: var(--button-color);
+    border-radius: 8px;
+    padding: 15px 20px;
+    margin-bottom: 25px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.total-unique-rooms {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px 10px;
+}
+
+.total-label {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.total-count {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text-color);
+    background-color: rgba(255, 255, 255, 0.2);
+    padding: 5px 15px;
+    border-radius: 20px;
+}
+
+.dark-mode .total-count {
+    background-color: rgba(0, 0, 0, 0.2);
 }

--- a/Frontend/css/statistics_style.css
+++ b/Frontend/css/statistics_style.css
@@ -56,6 +56,22 @@ h1 {
     font-weight: bold;
 }
 
+.room-count {
+    background-color: var(--button-color);
+    color: var(--text-color);
+    padding: 8px 20px;
+    font-weight: bold;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.room-count span {
+    display: inline-block;
+    background-color: var(--sub-container-color);
+    padding: 2px 8px;
+    border-radius: 12px;
+    margin-left: 5px;
+}
+
 .table-container {
     background-color: var(--secondary-color);
     padding: 20px;

--- a/Frontend/statistics.html
+++ b/Frontend/statistics.html
@@ -11,6 +11,7 @@
     <h1>Daily Curtain Control Statistics</h1>
     <div class="stats-container">
         <div class="date-header" id="currentDate"></div>
+        <div class="room-count">Unique Rooms Today: <span id="roomCount">0</span></div>
         <div class="table-container">
             <table>
                 <thead>
@@ -60,9 +61,13 @@
                 .then(data => {
                     const tbody = document.getElementById('statsBody');
                     const currentDate = document.getElementById('currentDate');
+                    const roomCountElement = document.getElementById('roomCount');
 
                     // Update date display
                     currentDate.textContent = formatDate(new Date());
+
+                    // Update room count
+                    roomCountElement.textContent = data.room_count || 0;
 
                     // Clear existing data
                     tbody.innerHTML = '';

--- a/server.py
+++ b/server.py
@@ -168,7 +168,10 @@ def get_stats(request: Request):
 @app.get("/stats/all")
 def get_all_stats(request: Request):
     """Get statistics for all days"""
-    return {"data": stats_manager.get_all_stats()}
+    return {
+        "data": stats_manager.get_all_stats(),
+        "total_unique_rooms": stats_manager.get_total_unique_rooms_count()
+    }
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -159,7 +159,10 @@ def control_curtain(request: Request, room_name: str, action: str, direction: st
 @app.get("/stats")
 def get_stats(request: Request):
     """Get statistics for the current day"""
-    return {"data": stats_manager.get_daily_stats()}
+    return {
+        "data": stats_manager.get_daily_stats(),
+        "room_count": stats_manager.get_room_count()
+    }
 
 
 @app.get("/stats/all")

--- a/statistics.py
+++ b/statistics.py
@@ -34,7 +34,8 @@ class StatisticsManager:
                     all_stats.append({
                         'date': formatted_date,
                         'raw_date': date,
-                        'stats': df.to_dict('records')
+                        'stats': df.to_dict('records'),
+                        'room_count': len(df['room_number'].unique())
                     })
                 except Exception as e:
                     logging.error(f"Error reading stats file {filename}: {e}")
@@ -116,3 +117,24 @@ class StatisticsManager:
         except Exception as e:
             logging.error(f"Error counting rooms in statistics file: {e}")
             return 0
+
+    def get_total_unique_rooms_count(self):
+        """
+        Count the number of unique rooms across all statistics history
+        
+        Returns:
+            int: Total number of unique rooms that have used the curtain control
+        """
+        all_rooms = set()
+        stats_files = os.listdir(self.stats_dir)
+        
+        for filename in stats_files:
+            if filename.startswith('stats_') and filename.endswith('.csv'):
+                filepath = os.path.join(self.stats_dir, filename)
+                try:
+                    df = pd.read_csv(filepath)
+                    all_rooms.update(df['room_number'].unique())
+                except Exception as e:
+                    logging.error(f"Error reading stats file {filename}: {e}")
+                    
+        return len(all_rooms)

--- a/statistics.py
+++ b/statistics.py
@@ -98,3 +98,21 @@ class StatisticsManager:
         except Exception as e:
             logging.error(f"Error reading statistics file: {e}")
             return []
+            
+    def get_room_count(self):
+        """
+        Count the number of unique rooms in today's statistics
+        
+        Returns:
+            int: Number of unique rooms that used the curtain control today
+        """
+        filename = self.get_stats_filename()
+        if not os.path.exists(filename):
+            return 0
+            
+        try:
+            df = pd.read_csv(filename)
+            return len(df['room_number'].unique())
+        except Exception as e:
+            logging.error(f"Error counting rooms in statistics file: {e}")
+            return 0


### PR DESCRIPTION
fixes #15 :

`Calculate number of rooms (not up/down/stop statistics) and present them in the statistics page. this way we can know how many new rooms joined us each day.`

Daily statistics now show unique number of rooms:
![image](https://github.com/user-attachments/assets/6c73e80b-2ba7-47bc-ab3c-fd70fb817656)


All statistics show unique rooms per day and unique rooms across all history:
![image](https://github.com/user-attachments/assets/873b0ab6-b666-44fd-b592-f0c2b7313785)
