### PR TITLE
Add SECURITY.md to support responsible disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a [GitHub Security Advisory](https://github.com/gaffner/OfficeCurtains/security/advisories/new).


### PR DESCRIPTION
Adds a minimal SECURITY.md file to enable GitHub's security advisory feature and provide a clear channel for responsible vulnerability disclosure.